### PR TITLE
Feature/improve output for nil value

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ render_data(nil) # => "<abbr class="text-muted" title="Not available">N/A</abbr>
 # You can override the message provided by passing the 'no_content_text' option:
 render_data(nil, :string, {no_content_text: "-"}) # => "<abbr class="text-muted" title="Not available">-</abbr>"
 
+# You can override the title of the abbreviation by passing the 'no_content_title' option:
+render_data(nil, :string, {no_content_title: "Not applicable"}) # => "<abbr class="text-muted" title="Not applicable">N/A</abbr>"
+
 # Boolean
 render_data(true, :boolean) # => "Yes"
 render_data(false, :boolean) # => "<span class="text-muted">No</span>"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In your view, use `render_data` to show data
 
 ```ruby
 # When rendering a nil object, no matter what type you'll get
-render_data(nil) # => "<span class="text-muted">N/A</span>"
+render_data(nil) # => "<abbr class="text-muted" title="Not available">N/A</abbr>"
 
 # Boolean
 render_data(true, :boolean) # => "Yes"
@@ -48,13 +48,15 @@ render_data("Jordan Rules!", :text, length: 6) # => "<span title='Jordan Rules!'
 
 ## Overriding default classes on N/A message
 
-You can override `FrontierDataRenderer.no_data_class` to provide your own CSS classes to be rendered on the 'N/A' span.
+You can override `FrontierDataRenderer.no_data_class` to provide your own CSS classes to be rendered on the 'N/A' `abbr` HTML element.
 
 You might want to create an initializer to do this. Example:
 
 ```ruby
 # in config/initializers/frontier_data_renderer.rb
 
-FrontierDataRenderer.no_data_class = "Jordan Rules" # Single class
-FrontierDataRenderer.no_data_class = ["Jordan", "Rules"] # Multiple classes
+FrontierDataRenderer.no_data_class = "text-quiet" # Single class
+# => "<abbr class="text-quiet" title="Not available">N/A</abbr>
+FrontierDataRenderer.no_data_class = ["text-quiet", "data-na"] # Multiple classes
+# => "<abbr class="text-quiet data-na" title="Not available">N/A</abbr>
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ In your view, use `render_data` to show data
 # When rendering a nil object, for all types except for boolean you'll get:
 render_data(nil) # => "<abbr class="text-muted" title="Not available">N/A</abbr>"
 
+# You can override the class by passing the 'no_data_class' option:
+render_data(nil, :string, {no_data_class: "yolo"}) # => "<abbr class="yolo" title="Not available">N/A</abbr>"
+
 # You can override the message provided by passing the 'no_data_text' option:
 render_data(nil, :string, {no_data_text: "-"}) # => "<abbr class="text-muted" title="Not available">-</abbr>"
 
@@ -52,7 +55,7 @@ render_data("Jordan Rules!", :text) # => "Jordan Rules!"
 render_data("Jordan Rules!", :text, length: 6) # => "<span title='Jordan Rules!'>Jor...</span>"
 ```
 
-## Overriding default classes on N/A message
+## Globally overriding empty data classes, messages, and titles
 
 You can override `FrontierDataRenderer.no_data_class` to provide your own CSS classes to be rendered on the 'N/A' `abbr` HTML element.
 
@@ -66,3 +69,6 @@ FrontierDataRenderer.no_data_class = "text-quiet" # Single class
 FrontierDataRenderer.no_data_class = ["text-quiet", "data-na"] # Multiple classes
 # => "<abbr class="text-quiet data-na" title="Not available">N/A</abbr>
 ```
+
+Local definitions via options will take precedence over global definitions
+.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ In your view, use `render_data` to show data
 render_data(nil) # => "<abbr class="text-muted" title="Not available">N/A</abbr>"
 
 # You can override the class by passing the 'no_data_class' option:
-render_data(nil, :string, {no_data_class: "yolo"}) # => "<abbr class="yolo" title="Not available">N/A</abbr>"
+render_data(nil, :string, {no_data_class: "text-quiet"}) # => "<abbr class="text-quiet" title="Not available">N/A</abbr>"
+render_data(nil, :string, {no_data_class: ["text-quiet", "data-na"]}) # => "<abbr class="text-quiet data-na" title="Not available">N/A</abbr>"
 
-# You can override the message provided by passing the 'no_data_text' option:
+# You can override the text provided by passing the 'no_data_text' option:
 render_data(nil, :string, {no_data_text: "-"}) # => "<abbr class="text-muted" title="Not available">-</abbr>"
 
 # You can override the title of the abbreviation by passing the 'no_data_title' option:
@@ -55,19 +56,19 @@ render_data("Jordan Rules!", :text) # => "Jordan Rules!"
 render_data("Jordan Rules!", :text, length: 6) # => "<span title='Jordan Rules!'>Jor...</span>"
 ```
 
-## Globally overriding empty data classes, messages, and titles
+## Globally overriding empty data CSS classes, text, and titles
 
-You can override `FrontierDataRenderer.no_data_class` to provide your own CSS classes to be rendered on the 'N/A' `abbr` HTML element.
-
-You might want to create an initializer to do this. Example:
+You can define global overrides in an initializer. EG:
 
 ```ruby
 # in config/initializers/frontier_data_renderer.rb
+FrontierDataRenderer.no_data_class = ["text-quiet", "data-na"]
+FrontierDataRenderer.no_data_text = "-"
+FrontierDataRenderer.no_boolean_data_text = "Nope"
+FrontierDataRenderer.no_data_title = "No data available"
 
-FrontierDataRenderer.no_data_class = "text-quiet" # Single class
-# => "<abbr class="text-quiet" title="Not available">N/A</abbr>
-FrontierDataRenderer.no_data_class = ["text-quiet", "data-na"] # Multiple classes
-# => "<abbr class="text-quiet data-na" title="Not available">N/A</abbr>
+# in your markup, this will yield:
+# <abbr class="text-quiet data-na" title="No data available">-</abbr>
 ```
 
 Local definitions via options will take precedence over global definitions

--- a/README.md
+++ b/README.md
@@ -14,17 +14,22 @@ In your view, use `render_data` to show data
 
 ```ruby
 # When rendering a nil object, for all types except for boolean you'll get:
-render_data(nil) # => "<abbr class="text-muted" title="Not available">N/A</abbr>"
+render_data(nil)
+# => "<abbr class="text-muted" title="Not available">N/A</abbr>"
 
 # You can override the class by passing the 'no_data_class' option:
-render_data(nil, :string, {no_data_class: "text-quiet"}) # => "<abbr class="text-quiet" title="Not available">N/A</abbr>"
-render_data(nil, :string, {no_data_class: ["text-quiet", "data-na"]}) # => "<abbr class="text-quiet data-na" title="Not available">N/A</abbr>"
+render_data(nil, :string, {no_data_class: "text-quiet"})
+# => "<abbr class="text-quiet" title="Not available">N/A</abbr>"
+render_data(nil, :string, {no_data_class: ["text-quiet", "data-na"]})
+# => "<abbr class="text-quiet data-na" title="Not available">N/A</abbr>"
 
 # You can override the text provided by passing the 'no_data_text' option:
-render_data(nil, :string, {no_data_text: "-"}) # => "<abbr class="text-muted" title="Not available">-</abbr>"
+render_data(nil, :string, {no_data_text: "-"})
+# => "<abbr class="text-muted" title="Not available">-</abbr>"
 
 # You can override the title of the abbreviation by passing the 'no_data_title' option:
-render_data(nil, :string, {no_data_title: "Not applicable"}) # => "<abbr class="text-muted" title="Not applicable">N/A</abbr>"
+render_data(nil, :string, {no_data_title: "Not applicable"})
+# => "<abbr class="text-muted" title="Not applicable">N/A</abbr>"
 
 # Boolean
 render_data(true, :boolean) # => "Yes"
@@ -71,5 +76,4 @@ FrontierDataRenderer.no_data_title = "No data available"
 # <abbr class="text-quiet data-na" title="No data available">-</abbr>
 ```
 
-Local definitions via options will take precedence over global definitions
-.
+Local definitions via options will take precedence over global definitions.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ gem "frontier_data_renderer", github: "thefrontiergroup/frontier_data_renderer"
 In your view, use `render_data` to show data
 
 ```ruby
-# When rendering a nil object, no matter what type you'll get
+# When rendering a nil object, for all types except for boolean you'll get:
 render_data(nil) # => "<abbr class="text-muted" title="Not available">N/A</abbr>"
+
+# You can override the message provided by passing the 'no_content_text' option:
+render_data(nil, :string, {no_content_text: "-"}) # => "<abbr class="text-muted" title="Not available">-</abbr>"
 
 # Boolean
 render_data(true, :boolean) # => "Yes"

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ In your view, use `render_data` to show data
 # When rendering a nil object, for all types except for boolean you'll get:
 render_data(nil) # => "<abbr class="text-muted" title="Not available">N/A</abbr>"
 
-# You can override the message provided by passing the 'no_content_text' option:
-render_data(nil, :string, {no_content_text: "-"}) # => "<abbr class="text-muted" title="Not available">-</abbr>"
+# You can override the message provided by passing the 'no_data_text' option:
+render_data(nil, :string, {no_data_text: "-"}) # => "<abbr class="text-muted" title="Not available">-</abbr>"
 
-# You can override the title of the abbreviation by passing the 'no_content_title' option:
-render_data(nil, :string, {no_content_title: "Not applicable"}) # => "<abbr class="text-muted" title="Not applicable">N/A</abbr>"
+# You can override the title of the abbreviation by passing the 'no_data_title' option:
+render_data(nil, :string, {no_data_title: "Not applicable"}) # => "<abbr class="text-muted" title="Not applicable">N/A</abbr>"
 
 # Boolean
 render_data(true, :boolean) # => "Yes"

--- a/lib/frontier_data_renderer.rb
+++ b/lib/frontier_data_renderer.rb
@@ -1,6 +1,6 @@
 class FrontierDataRenderer
   class << self
-    attr_accessor :no_data_class
+    attr_accessor :no_data_class, :no_data_text, :no_data_title
   end
 end
 

--- a/lib/frontier_data_renderer.rb
+++ b/lib/frontier_data_renderer.rb
@@ -1,10 +1,13 @@
 class FrontierDataRenderer
   class << self
-    attr_accessor :no_data_class, :no_data_text, :no_data_title
+    attr_accessor :no_boolean_data_text, :no_data_class, :no_data_text, :no_data_title
   end
 end
 
+FrontierDataRenderer.no_boolean_data_text = "No"
 FrontierDataRenderer.no_data_class = "text-muted"
+FrontierDataRenderer.no_data_text = "N/A"
+FrontierDataRenderer.no_data_title = "Not available"
 
 require_relative "frontier_data_renderer/view_helper"
 

--- a/lib/frontier_data_renderer/view_helper.rb
+++ b/lib/frontier_data_renderer/view_helper.rb
@@ -37,7 +37,10 @@ private
     if type == :boolean
       content_tag(:span, options[:no_content_text] || "No", class: FrontierDataRenderer.no_data_class)
     else
-      content_tag(:abbr, options[:no_content_text] || "N/A", class: FrontierDataRenderer.no_data_class, title: options[:no_content_title] || "Not available")
+      content_tag(:abbr, options[:no_content_text] || "N/A", {
+        class: FrontierDataRenderer.no_data_class,
+        title: options[:no_content_title] || "Not available"
+      })
     end
   end
 

--- a/lib/frontier_data_renderer/view_helper.rb
+++ b/lib/frontier_data_renderer/view_helper.rb
@@ -39,11 +39,11 @@ private
 
   def no_data_markup(type, options)
     if type == :boolean
-      content_tag(:span, options[:no_data_text] || "No", class: no_data_class(options))
+      content_tag(:span, options[:no_data_text] || FrontierDataRenderer.no_boolean_data_text, class: no_data_class(options))
     else
-      content_tag(:abbr, options[:no_data_text] || "N/A", {
+      content_tag(:abbr, options[:no_data_text] || FrontierDataRenderer.no_data_text, {
         class: no_data_class(options),
-        title: options[:no_data_title] || "Not available"
+        title: options[:no_data_title] || FrontierDataRenderer.no_data_title
       })
     end
   end

--- a/lib/frontier_data_renderer/view_helper.rb
+++ b/lib/frontier_data_renderer/view_helper.rb
@@ -33,12 +33,16 @@ private
     end
   end
 
+  def no_data_class(options)
+    options[:no_data_class] || FrontierDataRenderer.no_data_class
+  end
+
   def no_data_markup(type, options)
     if type == :boolean
-      content_tag(:span, options[:no_data_text] || "No", class: FrontierDataRenderer.no_data_class)
+      content_tag(:span, options[:no_data_text] || "No", class: no_data_class(options))
     else
       content_tag(:abbr, options[:no_data_text] || "N/A", {
-        class: FrontierDataRenderer.no_data_class,
+        class: no_data_class(options),
         title: options[:no_data_title] || "Not available"
       })
     end

--- a/lib/frontier_data_renderer/view_helper.rb
+++ b/lib/frontier_data_renderer/view_helper.rb
@@ -34,14 +34,10 @@ private
   end
 
   def no_data_message(type)
-    content_tag(:span, no_data_text(type), class: "text-muted")
-  end
-
-  def no_data_text(type)
     if type == :boolean
-      "No"
+      content_tag(:span, "No", class: FrontierDataRenderer.no_data_class)
     else
-      "N/A"
+      content_tag(:abbr, "N/A", class: FrontierDataRenderer.no_data_class, title: "Not available")
     end
   end
 

--- a/lib/frontier_data_renderer/view_helper.rb
+++ b/lib/frontier_data_renderer/view_helper.rb
@@ -1,30 +1,30 @@
 module FrontierDataRenderer::ViewHelper
 
- def render_data(value, type=:string, opts={})
+ def render_data(value, type=:string, options={})
     if value.present?
-      format_value(value, type, opts)
+      format_value(value, type, options)
     else
-      no_data_message(type)
+      no_data_markup(type, options)
     end
   end
 
 private
 
-  def format_value(value, type, opts)
+  def format_value(value, type, options)
     case type.to_sym
     when :boolean
-      value ? "Yes" : no_data_message(:boolean)
+      value ? "Yes" : no_data_markup(:boolean)
     when :currency
-      number_to_currency(value, opts)
+      number_to_currency(value, options)
     when :datetime
-      time_tag(value.to_datetime, opts.reverse_merge(format: :default))
+      time_tag(value.to_datetime, options.reverse_merge(format: :default))
     when :date
-      time_tag(value.to_date, opts.reverse_merge(format: :default))
+      time_tag(value.to_date, options.reverse_merge(format: :default))
     when :percentage
-      number_to_percentage(value, opts.reverse_merge(precision: 0))
+      number_to_percentage(value, options.reverse_merge(precision: 0))
     when :text
-      if opts[:length].present?
-        content_tag(:span, truncate(value, opts), title: value)
+      if options[:length].present?
+        content_tag(:span, truncate(value, options), title: value)
       else
         value
       end
@@ -33,11 +33,11 @@ private
     end
   end
 
-  def no_data_message(type)
+  def no_data_markup(type, options)
     if type == :boolean
-      content_tag(:span, "No", class: FrontierDataRenderer.no_data_class)
+      content_tag(:span, options[:no_content_text] || "No", class: FrontierDataRenderer.no_data_class)
     else
-      content_tag(:abbr, "N/A", class: FrontierDataRenderer.no_data_class, title: "Not available")
+      content_tag(:abbr, options[:no_content_text] || "N/A", class: FrontierDataRenderer.no_data_class, title: "Not available")
     end
   end
 

--- a/lib/frontier_data_renderer/view_helper.rb
+++ b/lib/frontier_data_renderer/view_helper.rb
@@ -37,7 +37,7 @@ private
     if type == :boolean
       content_tag(:span, options[:no_content_text] || "No", class: FrontierDataRenderer.no_data_class)
     else
-      content_tag(:abbr, options[:no_content_text] || "N/A", class: FrontierDataRenderer.no_data_class, title: "Not available")
+      content_tag(:abbr, options[:no_content_text] || "N/A", class: FrontierDataRenderer.no_data_class, title: options[:no_content_title] || "Not available")
     end
   end
 

--- a/lib/frontier_data_renderer/view_helper.rb
+++ b/lib/frontier_data_renderer/view_helper.rb
@@ -35,11 +35,11 @@ private
 
   def no_data_markup(type, options)
     if type == :boolean
-      content_tag(:span, options[:no_content_text] || "No", class: FrontierDataRenderer.no_data_class)
+      content_tag(:span, options[:no_data_text] || "No", class: FrontierDataRenderer.no_data_class)
     else
-      content_tag(:abbr, options[:no_content_text] || "N/A", {
+      content_tag(:abbr, options[:no_data_text] || "N/A", {
         class: FrontierDataRenderer.no_data_class,
-        title: options[:no_content_title] || "Not available"
+        title: options[:no_data_title] || "Not available"
       })
     end
   end

--- a/spec/lib/frontier_data_renderer/view_helper_spec.rb
+++ b/spec/lib/frontier_data_renderer/view_helper_spec.rb
@@ -8,9 +8,9 @@ describe FrontierDataRenderer::ViewHelper do
   end
 
   describe "#render_data" do
-    subject { helper.render_data(value, format, opts) }
+    subject { helper.render_data(value, format, options) }
     let(:helper) { FakeHelper.new }
-    let(:opts) { {} }
+    let(:options) { {} }
 
     context "with a value" do
       context "when format is a boolean" do
@@ -24,11 +24,6 @@ describe FrontierDataRenderer::ViewHelper do
 
         context "when false" do
           let(:value) { false }
-          it { should eq("<span class=\"text-muted\">No</span>") }
-        end
-
-        context "when nil" do
-          let(:value) { nil }
           it { should eq("<span class=\"text-muted\">No</span>") }
         end
       end
@@ -63,7 +58,7 @@ describe FrontierDataRenderer::ViewHelper do
         end
 
         context "with args" do
-          let(:opts) { {precision: 1} }
+          let(:options) { {precision: 1} }
           it { should include("55.7%") }
         end
       end
@@ -77,7 +72,7 @@ describe FrontierDataRenderer::ViewHelper do
         end
 
         context "and a length is specified" do
-          let(:opts) { {length: 5} }
+          let(:options) { {length: 5} }
           it { should eq("<span title=\"Thingo\">Th...</span>") }
         end
 
@@ -92,29 +87,64 @@ describe FrontierDataRenderer::ViewHelper do
     end
 
     context "when value is nil" do
-      context "when using default no_data_class" do
-        let(:format) { :string }
-        let(:value)  { nil }
-        it { should eq("<abbr class=\"text-muted\" title=\"Not available\">N/A</abbr>") }
+      let(:value)  { nil }
+
+      context "when type is boolean" do
+        let(:format) { :boolean }
+
+        context "when using default no_data_class" do
+          it { should eq("<span class=\"text-muted\">No</span>") }
+        end
+
+        describe "overriding FrontierDataRenderer.no_data_class" do
+          before { FrontierDataRenderer.no_data_class = no_data_class }
+          after  { FrontierDataRenderer.no_data_class = "text-muted" }
+
+          context "with a single class" do
+            let(:no_data_class) { "text-quiet" }
+            it { should eq("<span class=\"text-quiet\">No</span>") }
+          end
+
+          context "with multiple classes" do
+            let(:no_data_class) { ["text-quiet", "data-na"] }
+            it { should eq("<span class=\"text-quiet data-na\">No</span>") }
+          end
+        end
+
+        describe "overriding no_content_text" do
+          let(:options) { {no_content_text: "Yeah, nah"} }
+          it { should eq("<span class=\"text-muted\">Yeah, nah</span>") }
+        end
       end
 
-      context "when using single custom class for no_data_class" do
-        before { FrontierDataRenderer.no_data_class = "text-quiet" }
-        after  { FrontierDataRenderer.no_data_class = "text-muted" }
-
+      context "when type is not boolean" do
         let(:format) { :string }
-        let(:value)  { nil }
-        it { should eq("<abbr class=\"text-quiet\" title=\"Not available\">N/A</abbr>") }
+
+        context "when using default no_data_class" do
+          it { should eq("<abbr class=\"text-muted\" title=\"Not available\">N/A</abbr>") }
+        end
+
+        describe "overriding FrontierDataRenderer.no_data_class" do
+          before { FrontierDataRenderer.no_data_class = no_data_class }
+          after  { FrontierDataRenderer.no_data_class = "text-muted" }
+
+          context "with a single class" do
+            let(:no_data_class) { "text-quiet" }
+            it { should eq("<abbr class=\"text-quiet\" title=\"Not available\">N/A</abbr>") }
+          end
+
+          context "with multiple classes" do
+            let(:no_data_class) { ["text-quiet", "data-na"] }
+            it { should eq("<abbr class=\"text-quiet data-na\" title=\"Not available\">N/A</abbr>") }
+          end
+        end
+
+        describe "overriding no_content_text" do
+          let(:options) { {no_content_text: "Jordan rules"} }
+          it { should eq("<abbr class=\"text-muted\" title=\"Not available\">Jordan rules</abbr>") }
+        end
       end
 
-      context "when using multiple custom classes for no_data_class" do
-        before { FrontierDataRenderer.no_data_class = ["text-quiet", "data-na"] }
-        after  { FrontierDataRenderer.no_data_class = "text-muted" }
-
-        let(:format) { :string }
-        let(:value)  { nil }
-        it { should eq("<abbr class=\"text-quiet data-na\" title=\"Not available\">N/A</abbr>") }
-      end
     end
   end
 

--- a/spec/lib/frontier_data_renderer/view_helper_spec.rb
+++ b/spec/lib/frontier_data_renderer/view_helper_spec.rb
@@ -111,8 +111,8 @@ describe FrontierDataRenderer::ViewHelper do
           end
         end
 
-        describe "overriding no_content_text" do
-          let(:options) { {no_content_text: "Yeah, nah"} }
+        describe "overriding no_data_text" do
+          let(:options) { {no_data_text: "Yeah, nah"} }
           it { should eq("<span class=\"text-muted\">Yeah, nah</span>") }
         end
       end
@@ -139,13 +139,13 @@ describe FrontierDataRenderer::ViewHelper do
           end
         end
 
-        describe "overriding no_content_text" do
-          let(:options) { {no_content_text: "Jordan rules"} }
+        describe "overriding no_data_text" do
+          let(:options) { {no_data_text: "Jordan rules"} }
           it { should eq("<abbr class=\"text-muted\" title=\"Not available\">Jordan rules</abbr>") }
         end
 
-        describe "overriding no_content_title" do
-          let(:options) { {no_content_title: "Not applicable"} }
+        describe "overriding no_data_title" do
+          let(:options) { {no_data_title: "Not applicable"} }
           it { should eq("<abbr class=\"text-muted\" title=\"Not applicable\">N/A</abbr>") }
         end
       end

--- a/spec/lib/frontier_data_renderer/view_helper_spec.rb
+++ b/spec/lib/frontier_data_renderer/view_helper_spec.rb
@@ -143,6 +143,11 @@ describe FrontierDataRenderer::ViewHelper do
           let(:options) { {no_content_text: "Jordan rules"} }
           it { should eq("<abbr class=\"text-muted\" title=\"Not available\">Jordan rules</abbr>") }
         end
+
+        describe "overriding no_content_title" do
+          let(:options) { {no_content_title: "Not applicable"} }
+          it { should eq("<abbr class=\"text-muted\" title=\"Not applicable\">N/A</abbr>") }
+        end
       end
 
     end

--- a/spec/lib/frontier_data_renderer/view_helper_spec.rb
+++ b/spec/lib/frontier_data_renderer/view_helper_spec.rb
@@ -96,18 +96,26 @@ describe FrontierDataRenderer::ViewHelper do
           it { should eq("<span class=\"text-muted\">No</span>") }
         end
 
-        describe "overriding FrontierDataRenderer.no_data_class" do
+        describe "setting class on object" do
           before { FrontierDataRenderer.no_data_class = no_data_class }
           after  { FrontierDataRenderer.no_data_class = "text-muted" }
+          let(:no_data_class) { "text-quiet" }
 
-          context "with a single class" do
-            let(:no_data_class) { "text-quiet" }
-            it { should eq("<span class=\"text-quiet\">No</span>") }
+          describe "overriding FrontierDataRenderer.no_data_class" do
+            context "with a single class" do
+              let(:no_data_class) { "text-quiet" }
+              it { should eq("<span class=\"text-quiet\">No</span>") }
+            end
+
+            context "with multiple classes" do
+              let(:no_data_class) { ["text-quiet", "data-na"] }
+              it { should eq("<span class=\"text-quiet data-na\">No</span>") }
+            end
           end
 
-          context "with multiple classes" do
-            let(:no_data_class) { ["text-quiet", "data-na"] }
-            it { should eq("<span class=\"text-quiet data-na\">No</span>") }
+          describe "setting no_data_class option" do
+            let(:options) { {no_data_class: "yolo"} }
+            it { should eq("<span class=\"yolo\">No</span>") }
           end
         end
 
@@ -124,18 +132,26 @@ describe FrontierDataRenderer::ViewHelper do
           it { should eq("<abbr class=\"text-muted\" title=\"Not available\">N/A</abbr>") }
         end
 
-        describe "overriding FrontierDataRenderer.no_data_class" do
+        describe "setting class on object" do
           before { FrontierDataRenderer.no_data_class = no_data_class }
           after  { FrontierDataRenderer.no_data_class = "text-muted" }
+          let(:no_data_class) { "text-quiet" }
 
-          context "with a single class" do
-            let(:no_data_class) { "text-quiet" }
-            it { should eq("<abbr class=\"text-quiet\" title=\"Not available\">N/A</abbr>") }
+          describe "overriding FrontierDataRenderer.no_data_class" do
+            context "with a single class" do
+              let(:no_data_class) { "text-quiet" }
+              it { should eq("<abbr class=\"text-quiet\" title=\"Not available\">N/A</abbr>") }
+            end
+
+            context "with multiple classes" do
+              let(:no_data_class) { ["text-quiet", "data-na"] }
+              it { should eq("<abbr class=\"text-quiet data-na\" title=\"Not available\">N/A</abbr>") }
+            end
           end
 
-          context "with multiple classes" do
-            let(:no_data_class) { ["text-quiet", "data-na"] }
-            it { should eq("<abbr class=\"text-quiet data-na\" title=\"Not available\">N/A</abbr>") }
+          describe "setting no_data_class option" do
+            let(:options) { {no_data_class: "yolo"} }
+            it { should eq("<abbr class=\"yolo\" title=\"Not available\">N/A</abbr>") }
           end
         end
 

--- a/spec/lib/frontier_data_renderer/view_helper_spec.rb
+++ b/spec/lib/frontier_data_renderer/view_helper_spec.rb
@@ -97,6 +97,24 @@ describe FrontierDataRenderer::ViewHelper do
         let(:value)  { nil }
         it { should eq("<abbr class=\"text-muted\" title=\"Not available\">N/A</abbr>") }
       end
+
+      context "when using single custom class for no_data_class" do
+        before { FrontierDataRenderer.no_data_class = "text-quiet" }
+        after  { FrontierDataRenderer.no_data_class = "text-muted" }
+
+        let(:format) { :string }
+        let(:value)  { nil }
+        it { should eq("<abbr class=\"text-quiet\" title=\"Not available\">N/A</abbr>") }
+      end
+
+      context "when using multiple custom classes for no_data_class" do
+        before { FrontierDataRenderer.no_data_class = ["text-quiet", "data-na"] }
+        after  { FrontierDataRenderer.no_data_class = "text-muted" }
+
+        let(:format) { :string }
+        let(:value)  { nil }
+        it { should eq("<abbr class=\"text-quiet data-na\" title=\"Not available\">N/A</abbr>") }
+      end
     end
   end
 

--- a/spec/lib/frontier_data_renderer/view_helper_spec.rb
+++ b/spec/lib/frontier_data_renderer/view_helper_spec.rb
@@ -97,11 +97,15 @@ describe FrontierDataRenderer::ViewHelper do
         end
 
         describe "setting class on object" do
-          before { FrontierDataRenderer.no_data_class = no_data_class }
-          after  { FrontierDataRenderer.no_data_class = "text-muted" }
+          around do |example|
+            previous_value = FrontierDataRenderer.no_data_class
+            FrontierDataRenderer.no_data_class = no_data_class
+            example.run
+            FrontierDataRenderer.no_data_class = previous_value
+          end
           let(:no_data_class) { "text-quiet" }
 
-          describe "overriding FrontierDataRenderer.no_data_class" do
+          describe "globally" do
             context "with a single class" do
               let(:no_data_class) { "text-quiet" }
               it { should eq("<span class=\"text-quiet\">No</span>") }
@@ -113,15 +117,29 @@ describe FrontierDataRenderer::ViewHelper do
             end
           end
 
-          describe "setting no_data_class option" do
+          describe "locally" do
             let(:options) { {no_data_class: "yolo"} }
             it { should eq("<span class=\"yolo\">No</span>") }
           end
         end
 
-        describe "overriding no_data_text" do
-          let(:options) { {no_data_text: "Yeah, nah"} }
-          it { should eq("<span class=\"text-muted\">Yeah, nah</span>") }
+        describe "overriding text" do
+          around do |example|
+            previous_value = FrontierDataRenderer.no_boolean_data_text
+            FrontierDataRenderer.no_boolean_data_text = no_boolean_data_text
+            example.run
+            FrontierDataRenderer.no_boolean_data_text = previous_value
+          end
+          let(:no_boolean_data_text) { "Nah" }
+
+          context "globally" do
+            it { should eq("<span class=\"text-muted\">Nah</span>") }
+          end
+
+          context "locally" do
+            let(:options) { {no_data_text: "Yeah, nah"} }
+            it { should eq("<span class=\"text-muted\">Yeah, nah</span>") }
+          end
         end
       end
 
@@ -132,14 +150,17 @@ describe FrontierDataRenderer::ViewHelper do
           it { should eq("<abbr class=\"text-muted\" title=\"Not available\">N/A</abbr>") }
         end
 
-        describe "setting class on object" do
-          before { FrontierDataRenderer.no_data_class = no_data_class }
-          after  { FrontierDataRenderer.no_data_class = "text-muted" }
+        describe "globally" do
+          around do |example|
+            previous_value = FrontierDataRenderer.no_data_class
+            FrontierDataRenderer.no_data_class = no_data_class
+            example.run
+            FrontierDataRenderer.no_data_class = previous_value
+          end
           let(:no_data_class) { "text-quiet" }
 
           describe "overriding FrontierDataRenderer.no_data_class" do
             context "with a single class" do
-              let(:no_data_class) { "text-quiet" }
               it { should eq("<abbr class=\"text-quiet\" title=\"Not available\">N/A</abbr>") }
             end
 
@@ -149,20 +170,48 @@ describe FrontierDataRenderer::ViewHelper do
             end
           end
 
-          describe "setting no_data_class option" do
+          describe "locally" do
             let(:options) { {no_data_class: "yolo"} }
             it { should eq("<abbr class=\"yolo\" title=\"Not available\">N/A</abbr>") }
           end
         end
 
-        describe "overriding no_data_text" do
-          let(:options) { {no_data_text: "Jordan rules"} }
-          it { should eq("<abbr class=\"text-muted\" title=\"Not available\">Jordan rules</abbr>") }
+        describe "overriding text" do
+          around do |example|
+            previous_value = FrontierDataRenderer.no_data_text
+            FrontierDataRenderer.no_data_text = no_data_text
+            example.run
+            FrontierDataRenderer.no_data_text = previous_value
+          end
+          let(:no_data_text) { "No data, hey" }
+
+          context "globally" do
+            it { should eq("<abbr class=\"text-muted\" title=\"Not available\">No data, hey</abbr>") }
+          end
+
+          context "locally" do
+            let(:options) { {no_data_text: "Jordan rules"} }
+            it { should eq("<abbr class=\"text-muted\" title=\"Not available\">Jordan rules</abbr>") }
+          end
         end
 
-        describe "overriding no_data_title" do
-          let(:options) { {no_data_title: "Not applicable"} }
-          it { should eq("<abbr class=\"text-muted\" title=\"Not applicable\">N/A</abbr>") }
+        describe "overriding title" do
+          around do |example|
+            previous_value = FrontierDataRenderer.no_data_title
+            FrontierDataRenderer.no_data_title = no_data_title
+            example.run
+            FrontierDataRenderer.no_data_title = previous_value
+          end
+          let(:no_data_title) { "No data, hey" }
+
+          context "globally" do
+            it { should eq("<abbr class=\"text-muted\" title=\"No data, hey\">N/A</abbr>") }
+          end
+
+          context "locally" do
+            let(:options) { {no_data_title: "Not applicable"} }
+            it { should eq("<abbr class=\"text-muted\" title=\"Not applicable\">N/A</abbr>") }
+          end
         end
       end
 

--- a/spec/lib/frontier_data_renderer/view_helper_spec.rb
+++ b/spec/lib/frontier_data_renderer/view_helper_spec.rb
@@ -92,9 +92,11 @@ describe FrontierDataRenderer::ViewHelper do
     end
 
     context "when value is nil" do
-      let(:format) { :string }
-      let(:value)  { nil }
-      it { should include("N/A") }
+      context "when using default no_data_class" do
+        let(:format) { :string }
+        let(:value)  { nil }
+        it { should eq("<abbr class=\"text-muted\" title=\"Not available\">N/A</abbr>") }
+      end
     end
   end
 


### PR DESCRIPTION
# Improve output for `nil` value
- [x] Change `span` output to `abbr` for `N/A`
- [x] Update helper to allow custom classes for `N/A` message
- [x] Add tests
- [x] Update README

``` ruby
FrontierDataRenderer::ViewHelper
  #render_data
    with a value
      when format is a boolean
        when true
          should eq "Yes"
        when false
          should eq "<span class=\"text-muted\">No</span>"
        when nil
          should eq "<span class=\"text-muted\">No</span>"
      when format is a currency
        should include "$69.12"
      when format is a datetime
        should include "Tue, 19 May 2015 17:24:00 +0000"
      when format is a date
        should include "2015-05-19"
      when format is a percentage
        without args
          should include "56%"
        with args
          should include "55.7%"
      when format is a text
        and no length is specified
          should eq "Thingo"
        and a length is specified
          should eq "<span title=\"Thingo\">Th...</span>"
      when format is a string
        should eq "Thing"
    when value is nil
      when using default no_data_class
        should eq "<abbr class=\"text-muted\" title=\"Not available\">N/A</abbr>"
      when using single custom class for no_data_class
        should eq "<abbr class=\"text-quiet\" title=\"Not available\">N/A</abbr>"
      when using multiple custom classes for no_data_classes
        should eq "<abbr class=\"text-quiet data-na\" title=\"Not available\">N/A</abbr>"

Finished in 0.02507 seconds (files took 0.75258 seconds to load)
14 examples, 0 failures
```

With ❤️ 
Patrik
